### PR TITLE
axosyslog-collector: add image.extraArgs

### DIFF
--- a/charts/axosyslog-collector/Chart.yaml
+++ b/charts/axosyslog-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: axosyslog-collector
-description: AxoSyslog kubernetes log collector
+description: AxoSyslog Kubernetes log collector
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: "4.1.1"

--- a/charts/axosyslog-collector/templates/daemonset.yaml
+++ b/charts/axosyslog-collector/templates/daemonset.yaml
@@ -101,6 +101,10 @@ spec:
         - name: "axosyslog-collector"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          {{- if .Values.image.extraArgs }}
+          args:
+{{ toYaml .Values.image.extraArgs | indent 12 }}
+          {{- end }}
           resources:
 {{ toYaml ( .Values.resources | default .Values.daemonset.resources ) | indent 12 }}
           securityContext: {{ toYaml ( .Values.podSecurityContext | default .Values.daemonset.securityContext ) | nindent 12 }}

--- a/charts/axosyslog-collector/values.yaml
+++ b/charts/axosyslog-collector/values.yaml
@@ -2,6 +2,7 @@ image:
   repository: ghcr.io/axoflow/axosyslog
   pullPolicy: IfNotPresent
   tag: "nightly" # until releasing v4.2
+  extraArgs: []
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
For example, for moving the `syslog-ng.ctl` socket to a shared volume.