### PR TITLE
collector: add set rewrites configurability 

### DIFF
--- a/charts/axosyslog-collector/Chart.yaml
+++ b/charts/axosyslog-collector/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: axosyslog-collector
 description: AxoSyslog Kubernetes log collector
 type: application
-version: 0.7.0
+version: 0.8.0
 appVersion: "4.5.0"

--- a/charts/axosyslog-collector/templates/config.yaml
+++ b/charts/axosyslog-collector/templates/config.yaml
@@ -43,6 +43,13 @@ data:
         opentelemetry();
       };
 {{- end }}
+{{- with .Values.config.rewrites.set }}
+      rewrite {
+{{- range $k, $v := . }}
+        set({{ $v | quote }} value({{ $k | quote }}));
+{{- end }}
+      };
+{{- end }}
 {{- range .Values.config.destinations.file }}
       destination {
         file(

--- a/charts/axosyslog-collector/values.yaml
+++ b/charts/axosyslog-collector/values.yaml
@@ -54,6 +54,11 @@ config:
   parsers:
     opentelemetry:
       enabled: false
+  rewrites:
+    set: {}
+#   E.g.:
+#     foo: "${foovalue}"
+#     bar: "${barvalue}"
   destinations:
     file: []
 #   E.g.:


### PR DESCRIPTION
Example to copy the time field from the kubernetes metadata to the top level
```
daemonset:
  enabled: true
config:
  sources:
    kubernetes:
      enabled: true
      prefix: "kubernetes#"
      keyDelimiter: "#"
  rewrites:
    set:
      time: "${kubernetes#time}"
  destinations:
    network:
    - transport: tcp
      address: logging-syslog-ng.logging.svc.cluster.local
      port: 601
      template: "$(format-json --key-delimiter # --scope all-nv-pairs)\\n"
      extraOptionsRaw: "time-reopen(10)"
```